### PR TITLE
Updates test.js so casting via commandline works

### DIFF
--- a/cli/test.js
+++ b/cli/test.js
@@ -12,7 +12,7 @@ nodecastor.scan()
             console.log('Application', util.inspect(a));
             a.run('urn:x-cast:es.offd.dashcast', function(err, s) {
               if (!err) {
-                s.send('http://theregister.co.uk');
+                s.send({url: "http://codepen.io/fleeting/full/xklfq/"});
               }
             });
           }


### PR DESCRIPTION
I wanted to be able to cast to my chromecast via command line from my raspberry pi. Now test.js is fixed.